### PR TITLE
wijziging omschrijving solar app

### DIFF
--- a/ToonRepo.xml
+++ b/ToonRepo.xml
@@ -107,7 +107,7 @@
 		<name>Solar Panel</name>
 		<version>1.3.3</version>
 		<folder>solarPanel</folder>
-		<description>Bekijk de opbrengst van je zonnepanelen</description>
+		<description>Bekijk de opbrengst van je zonnepanelen. Niet installeren als je ZonOpToon, via qubino smart meter of via meteradapter, al hebt.</description>
 		<author>oepi-loepie</author>
 		<skipautoupdate>no</skipautoupdate>
 		<screenshots>7</screenshots>

--- a/ToonRepo.xml
+++ b/ToonRepo.xml
@@ -157,7 +157,7 @@
 	</app>
 	<app>
 		<name>Voetbalscores</name>
-		<version>1.0.33</version>
+		<version>1.0.34</version>
 		<folder>voetbal</folder>
 		<description>Laat voetbalscores zien (icm Animation app)</description>
 		<author>oepi-loepi</author>

--- a/ToonRepo.xml
+++ b/ToonRepo.xml
@@ -157,7 +157,7 @@
 	</app>
 	<app>
 		<name>Voetbalscores</name>
-		<version>1.0.34</version>
+		<version>1.0.35</version>
 		<folder>voetbal</folder>
 		<description>Laat voetbalscores zien (icm Animation app)</description>
 		<author>oepi-loepi</author>


### PR DESCRIPTION
Kleine wijziging in omschrijving solar app zodat mensen deze app niet installeren als ze al zonoptoon gebruiken.