### PR TITLE
Update Toon MQTT test catalog to 1.2.4

### DIFF
--- a/ToonRepo.xml
+++ b/ToonRepo.xml
@@ -14,7 +14,7 @@
 	</app>
 	<app>
 		<name>Toon MQTT</name>
-		<version>1.2.3</version>
+		<version>1.2.4</version>
 		<folder>toonmqtt</folder>
 		<description>Lokale MQTT-koppeling met Home Assistant climate, Toon-bediening en injectie van elektriciteits- en gasmeterdata.</description>
 		<author>Toon MQTT contributors</author>


### PR DESCRIPTION
Small Toon 2 UI test update.

- Editing a setting now opens a separate edit view above the on-screen keyboard.
- The active field remains visible while typing.
- Tested successfully on a real Toon 2.
- MQTT, energy injection and service behavior are unchanged.

Release: https://github.com/phoenix-blue/toonmqtt/releases/tag/1.2.4

Before installation through the test Store, tag `1.2.4` also needs to be synchronized to `ToonSoftwareCollective/toonmqtt`.