### PR TITLE
Promote Toon MQTT 1.2.4 to main catalog

### DIFF
--- a/ToonRepo.xml
+++ b/ToonRepo.xml
@@ -13,6 +13,19 @@
 		<allowdeletion>no</allowdeletion>
 	</app>
 	<app>
+		<name>Toon MQTT</name>
+		<version>1.2.4</version>
+		<folder>toonmqtt</folder>
+		<description>Lokale MQTT-koppeling met Home Assistant climate, Toon-bediening en injectie van elektriciteits- en gasmeterdata.</description>
+		<author>Toon MQTT contributors</author>
+		<skipautoupdate>no</skipautoupdate>
+		<screenshots>4</screenshots>
+		<firmwareminimum>5.0.00</firmwareminimum>
+		<firmwaremaximum>9.99.9</firmwaremaximum>
+		<toon2only>yes</toon2only>
+		<allowdeletion>yes</allowdeletion>
+	</app>
+	<app>
 		<name>Buienradar</name>
 		<version>9.1.11</version>
 		<folder>buienradar</folder>


### PR DESCRIPTION
Promotes the tested Toon MQTT 1.2.4 app entry from the test catalog to the main catalog.

- Toon 2 only
- release tag 1.2.4 is available in ToonSoftwareCollective/toonmqtt
- install and uninstall were tested through ToonStore
- keyboard editor fix was tested on a physical Toon 2
- four privacy-safe screenshots are already available in the main catalog repository

No application files or unrelated catalog entries are changed by this pull request.